### PR TITLE
Add Map

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ Change Log
 
 under development
 -----------------
+- Add `Map`: an alias of map[string]interface{}.
 
 v1.10.0 April 11, 2020
 ----------------------

--- a/clevergo.go
+++ b/clevergo.go
@@ -4,3 +4,6 @@
 
 // Package clevergo is a trie based high performance HTTP request router.
 package clevergo
+
+// Map is an alias of map[string]interface{}.
+type Map map[string]interface{}


### PR DESCRIPTION
An alias of `map[string]interface{}`. Similar to `gin.H` and `echo.Map`.