### PR TITLE
Uniform code style: Context.Error and Context.Redirect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Change Log
 under development
 -----------------
 - `Context.Error`, `Context.NotFound`, `Context.Redirect`, `Context.ServeFile`, `Context.ServeContent` return a nil error.
+- `Context.Error(msg string, code int)` was changed as `Context.Error(code int, msg string)`.
+- `Context.Redirect(url string, code int)` was changed as `Context.Redirect(code int, url string)`.
 
 v1.12.1 May 5, 2020
 -------------------

--- a/context.go
+++ b/context.go
@@ -88,7 +88,7 @@ func (ctx *Context) reset() {
 }
 
 // Error is a shortcut of http.Error.
-func (ctx *Context) Error(msg string, code int) error {
+func (ctx *Context) Error(code int, msg string) error {
 	http.Error(ctx.Response, msg, code)
 	return nil
 }
@@ -100,7 +100,7 @@ func (ctx *Context) NotFound() error {
 }
 
 // Redirect is a shortcut of http.Redirect.
-func (ctx *Context) Redirect(url string, code int) error {
+func (ctx *Context) Redirect(code int, url string) error {
 	http.Redirect(ctx.Response, ctx.Request, url, code)
 	return nil
 }

--- a/context_test.go
+++ b/context_test.go
@@ -92,7 +92,7 @@ func TestContext_NotFound(t *testing.T) {
 func TestContext_Redirect(t *testing.T) {
 	w := httptest.NewRecorder()
 	ctx := newContext(w, httptest.NewRequest(http.MethodGet, "/", nil))
-	assert.Nil(t, ctx.Redirect("/redirect", http.StatusPermanentRedirect))
+	assert.Nil(t, ctx.Redirect(http.StatusPermanentRedirect, "/redirect"))
 	assert.Equal(t, http.StatusPermanentRedirect, w.Code)
 }
 func TestContext_Error(t *testing.T) {
@@ -107,7 +107,7 @@ func TestContext_Error(t *testing.T) {
 	for _, test := range tests {
 		w := httptest.NewRecorder()
 		ctx := newContext(w, nil)
-		assert.Nil(t, ctx.Error(test.msg, test.code))
+		assert.Nil(t, ctx.Error(test.code, test.msg))
 		assert.Equal(t, fmt.Sprintln(test.msg), w.Body.String())
 		assert.Equal(t, test.code, w.Code)
 	}

--- a/router.go
+++ b/router.go
@@ -400,7 +400,7 @@ func (r *Router) handleRequest(ctx *Context) (err error) {
 				} else {
 					path = path + "/"
 				}
-				ctx.Redirect(path, code)
+				ctx.Redirect(code, path)
 				return
 			}
 
@@ -411,7 +411,7 @@ func (r *Router) handleRequest(ctx *Context) (err error) {
 					r.RedirectTrailingSlash,
 				)
 				if found {
-					ctx.Redirect(fixedPath, code)
+					ctx.Redirect(code, fixedPath)
 					return
 				}
 			}
@@ -458,8 +458,8 @@ func (r *Router) HandleError(ctx *Context, err error) {
 
 	switch e := err.(type) {
 	case StatusError:
-		ctx.Error(err.Error(), e.Status())
+		ctx.Error(e.Status(), err.Error())
 	default:
-		ctx.Error(err.Error(), http.StatusInternalServerError)
+		ctx.Error(http.StatusInternalServerError, err.Error())
 	}
 }

--- a/router_test.go
+++ b/router_test.go
@@ -662,7 +662,7 @@ type testErrorHandler struct {
 }
 
 func (eh testErrorHandler) Handle(ctx *Context, err error) {
-	ctx.Error(err.Error(), eh.status)
+	ctx.Error(eh.status, err.Error())
 }
 
 func TestRouter_ErrorHandler(t *testing.T) {


### PR DESCRIPTION
This patch contains two breaking changes:
- `Context.Error(msg string, code int)` was changed as `Context.Error(code int, msg string)`.
- `Context.Redirect(url string, code int)` was changed as `Context.Redirect(code int, url string)`.